### PR TITLE
Support large numbers of arguments

### DIFF
--- a/linker.sh
+++ b/linker.sh
@@ -41,6 +41,9 @@ done
 
 log_file="$(path_l2w "$script_path/last-linking.log")"
 
-echo "& \"$linker_exec\" $args | Out-file \"$log_file\"" >> "$script_path/last-linking.ps1"
+commands_file="$(path_l2w "$script_path/last-linking-args.txt")"
+echo "$args" > "$script_path/last-linking-args.txt"
+
+echo "& \"$linker_exec\" \"@$commands_file\" | Out-file \"$log_file\"" >> "$script_path/last-linking.ps1"
 
 powershell.exe -Command "$script_path/last-linking.ps1"


### PR DESCRIPTION
The script, in its current form, breaks when called with too many or too long command line arguments.

To avoid this, arguments can be passed in through a file, as documented here: [CL Command Files](https://docs.microsoft.com/en-us/cpp/build/reference/cl-command-files?view=msvc-160). Then `@file` is added on the command line, which tells MSVC to read arguments from the file.