### PR TITLE
Avoid remote ps exec with copy to /mnt/c/temp

### DIFF
--- a/linker.sh
+++ b/linker.sh
@@ -46,4 +46,6 @@ echo "$args" > "$script_path/last-linking-args.txt"
 
 echo "& \"$linker_exec\" \"@$commands_file\" | Out-file \"$log_file\"" >> "$script_path/last-linking.ps1"
 
-powershell.exe -Command "$script_path/last-linking.ps1"
+mkdir /mnt/c/temp
+cp $script_path/last-linking.ps1 /mnt/c/temp
+cmd.exe /c "cd C:\temp & powershell.exe -Command .\last-linking.ps1"


### PR DESCRIPTION
Running the original linker.sh gave a powershell authorization error because it thinks WSL is running in a server:

![image](https://github.com/strickczq/msvc-wsl-rust/assets/19553486/86bb8596-3143-43ff-a092-55ed37bc4853)

I was able to avoid this authorization error by copying to C:\temp before executing the script.

More info on the error: https://setspn.blogspot.com/2011/05/running-powershell-scripts-from-unc.html 